### PR TITLE
Change Max7219_idle_task() routines to use single line if X-Axis has …

### DIFF
--- a/Marlin/Max7219_Debug_LEDs.cpp
+++ b/Marlin/Max7219_Debug_LEDs.cpp
@@ -410,22 +410,38 @@ void Max7219_init() {
 
 // Apply changes to update a marker
 inline void Max7219_Mark16(const uint8_t y, const uint8_t v1, const uint8_t v2) {
-  Max7219_LED_Off(v1 & 0x7, y + (v1 >= 8));
-   Max7219_LED_On(v2 & 0x7, y + (v2 >= 8));
+  #if MAX7219_X_LEDS == 8
+    Max7219_LED_Off(v1 & 0x7, y + (v1 >= 8));
+     Max7219_LED_On(v2 & 0x7, y + (v2 >= 8));
+  #else   // LED matrix has at least 16 LED's on the X-Axis.  Use single line of LED's
+    Max7219_LED_Off(v1 & 0xf, y);
+     Max7219_LED_On(v2 & 0xf, y);
+  #endif
 }
 
 // Apply changes to update a tail-to-head range
 inline void Max7219_Range16(const uint8_t y, const uint8_t ot, const uint8_t nt, const uint8_t oh, const uint8_t nh) {
-  if (ot != nt) for (uint8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
-    Max7219_LED_Off(n & 0x7, y + (n >= 8));
-  if (oh != nh) for (uint8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
-     Max7219_LED_On(n & 0x7, y + (n >= 8));
+  #if MAX7219_X_LEDS == 8
+    if (ot != nt) for (uint8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
+      Max7219_LED_Off(n & 0x7, y + (n >= 8));
+    if (oh != nh) for (uint8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
+       Max7219_LED_On(n & 0x7, y + (n >= 8));
+  #else   // LED matrix has at least 16 LED's on the X-Axis.  Use single line of LED's
+    if (ot != nt) for (uint8_t n = ot & 0xF; n != (nt & 0xF) && n != (nh & 0xF); n = (n + 1) & 0xF)
+      Max7219_LED_Off(n & 0xf, y);
+    if (oh != nh) for (uint8_t n = (oh + 1) & 0xF; n != ((nh + 1) & 0xF); n = (n + 1) & 0xF)
+       Max7219_LED_On(n & 0xf, y);
+ #endif
 }
 
 // Apply changes to update a quantity
 inline void Max7219_Quantity16(const uint8_t y, const uint8_t ov, const uint8_t nv) {
   for (uint8_t i = MIN(nv, ov); i < MAX(nv, ov); i++)
-    Max7219_LED_Set(i >> 1, y + (i & 1), nv >= ov);
+    #if MAX7219_X_LEDS == 8
+      Max7219_LED_Set(i >> 1, y + (i & 1), nv >= ov); // single 8x8 LED matrix.  Use two lines to get 16 LED's
+    #else
+      Max7219_LED_Set(i, y, nv >= ov);                // LED matrix has at least 16 LED's on the X-Axis.  Use single line of LED's
+    #endif
 }
 
 void Max7219_idle_tasks() {


### PR DESCRIPTION
…16 or more LED's

Change Max7219_idle_task() routines to use single line if X-Axis has 16 or more LED's

This gets bugfix_1.1.x at parity with https://github.com/MarlinFirmware/Marlin/pull/11285 when it gets merged.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
